### PR TITLE
Make about text for commands consistent

### DIFF
--- a/cita-cli/src/cli/rpc_command.rs
+++ b/cita-cli/src/cli/rpc_command.rs
@@ -19,7 +19,7 @@ pub fn rpc_command() -> App<'static, 'static> {
         .subcommand(SubCommand::with_name("blockNumber").about("Get current height"))
         .subcommand(
             SubCommand::with_name("sendRawTransaction")
-                .about("Send a transaction return transaction hash")
+                .about("Send a transaction and return transaction hash")
                 .arg(
                     Arg::with_name("code")
                         .long("code")
@@ -315,7 +315,7 @@ pub fn rpc_command() -> App<'static, 'static> {
                 ),
         ).subcommand(
             SubCommand::with_name("newFilter")
-                .about("Creates a filter object")
+                .about("Create a filter object")
                 .arg(
                     Arg::with_name("address")
                         .long("address")

--- a/cita-tool/src/client/basic.rs
+++ b/cita-tool/src/client/basic.rs
@@ -515,7 +515,7 @@ where
     fn get_peer_count(&self) -> Self::RpcResult;
     /// blockNumber: Get current height
     fn get_block_number(&self) -> Self::RpcResult;
-    /// sendTransaction: Send a transaction return transaction hash
+    /// sendTransaction: Send a transaction and return transaction hash
     fn send_raw_transaction(&mut self, transaction_option: TransactionOptions) -> Self::RpcResult;
     /// getBlockByHash: Get block by hash
     fn get_block_by_hash(&self, hash: &str, transaction_info: bool) -> Self::RpcResult;


### PR DESCRIPTION
Except the default help about text (`Prints this message or the help of the given subcommand(s)`, which I assume was from Rust lib?), commands have about text in second person.